### PR TITLE
Fix timer deactivation after stopping a backup

### DIFF
--- a/bin/omarchy-time-machine
+++ b/bin/omarchy-time-machine
@@ -1708,7 +1708,6 @@ timer_unit() {
   cat <<UNIT
 [Unit]
 Description=Time Machine backup to $name
-Requires=omarchy-time-machine@$name.service
 
 [Timer]
 Unit=omarchy-time-machine@$name.service

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -376,6 +376,13 @@ for unit in "omarchy-time-machine@.service" "omarchy-time-machine-failed@.servic
   check $? "install writes $unit"
 done
 
+# A timer starts its service through Unit=; it must not Require that service.
+# Otherwise cancelling one running backup deactivates the long-lived timer and
+# silently prevents every future scheduled backup.
+! grep -q '^Requires=omarchy-time-machine@test.service$' \
+  "$XDG_CONFIG_HOME/systemd/user/omarchy-time-machine@test.timer"
+check $? "cancelling a backup cannot deactivate its timer"
+
 # restic exits 3 when it could not read a source file. The snapshot it writes
 # then has holes in it, and calling that a success is how a backup rots
 # unnoticed: the last snapshot that still held the file ages out, prune


### PR DESCRIPTION
Fixes #5.

## Summary

- remove the timer's `Requires=` dependency on its oneshot backup service
- retain `Unit=`, which is the timer's intended activation mechanism
- add a regression assertion that generated timers do not reintroduce the dependency

Stopping a running backup now cancels only that run. The scheduled timer remains active for its next run.

## Validation

- reproduced the original stop-propagation behavior with an isolated user-systemd test
- ran the regression suite in isolated temporary XDG directories
- baseline (`ba8f8bb`): 62 passed, 21 failed
- this branch: 63 passed, 21 failed

The 21 existing failures are unchanged from the baseline and occur in unrelated restic and systemd verification cases.
